### PR TITLE
zero in negative values after interpolation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 ExoPhotProject
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/codes/spectral_overlap_functions.py
+++ b/codes/spectral_overlap_functions.py
@@ -259,6 +259,11 @@ def wavelength_interpolate(flux, trans, sigma):
     t_int = cs_t(wl_int)
     s_int = cs_s(wl_int)
     
+    # zero in negative values (they may appear after interpolation)
+    f_int[f_int<0] = 0
+    t_int[t_int<0] = 0
+    s_int[s_int<0] = 0
+    
     # concatenate interpolated wavelengths and spectra
     flux_int = np.column_stack((wl_int,f_int))
     trans_int = np.column_stack((wl_int,t_int))


### PR DESCRIPTION
It may happen that the interpolated values of the flux, transmittance or absorbance become negative in some spectral ranges due to the presence of zeros in the original variables. This artifact would contribute decreasing the absorption rates artificially. This commit solves this potential problem by zero in all the posible negative values after interpolation.